### PR TITLE
fix(webview): bridge clipboard paste through extension host

### DIFF
--- a/extension/webview.ts
+++ b/extension/webview.ts
@@ -192,6 +192,14 @@ class PanelProvider implements vscode.WebviewViewProvider, vscode.Disposable {
           if (res === 'Copy Details')
             vscode.env.clipboard.writeText(e instanceof Error && e.stack ? e.stack : String(e));
         }
+        break;
+
+      case 'clipboard:read':
+        this.postEvent({
+          type: 'clipboard:text',
+          text: await vscode.env.clipboard.readText(),
+        });
+        break;
     }
   }
 }

--- a/shared/events.ts
+++ b/shared/events.ts
@@ -100,4 +100,9 @@ export type EventMessage = { // extension -> webview
 } | { // extension -> webview
   type: 'oj:samples-fetched'
   samples?: ProblemIOSample[]
+} | { // webview -> extension
+  type: 'clipboard:read'
+} | { // extension -> webview
+  type: 'clipboard:text'
+  text: string
 };

--- a/src/components/IOPanel.vue
+++ b/src/components/IOPanel.vue
@@ -5,7 +5,7 @@ import { IconFileSymlinkFile } from '@iconify-prerendered/vue-codicon';
 import { IconLoadingLoop } from '@iconify-prerendered/vue-line-md';
 import * as monaco from 'monaco-editor';
 import { computed, inject, ref, shallowRef, watchEffect } from 'vue';
-import { selectFile, ThemeInjectKey, useFontSize } from '../utils';
+import { readClipboard, selectFile, ThemeInjectKey, useFontSize } from '../utils';
 
 const props = defineProps<{
   modelPath: string
@@ -72,6 +72,27 @@ async function linkFile() {
   }
 }
 
+function handleMount(editor: monaco.editor.IStandaloneCodeEditor) {
+  outputEditor.value = editor;
+  // Bridge clipboard paste through the extension host: in production VS Code
+  // webviews Monaco's built-in paste fails because `navigator.clipboard.readText()`
+  // requires `clipboard-read` permission that the prod webview lacks (see issue #26).
+  // Only register on editable editors (Input panel); skip readonly / diff editors.
+  if (props.readonly || props.diff)
+    return;
+  editor.addAction({
+    id: 'oi-runner-2.clipboard.paste',
+    label: 'Paste',
+    keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyV],
+    run: async (ed) => {
+      const text = await readClipboard();
+      const sels = ed.getSelections();
+      if (sels)
+        ed.executeEdits('oi-runner-2.clipboard-paste', sels.map(range => ({ range, text, forceMoveMarkers: true })));
+    },
+  });
+}
+
 defineExpose({
   getContent() {
     if (!props.diff)
@@ -115,7 +136,7 @@ defineExpose({
     <VueMonacoEditor
       v-show="!diff"
       v-bind="monacoProps"
-      @mount="e => outputEditor = e"
+      @mount="handleMount"
     />
 
     <VueMonacoDiffEditor

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,6 +75,17 @@ export async function selectFile() {
   return (await waitEvent('file:selected')).path;
 }
 
+/**
+ * Read the system clipboard via the extension host.
+ * Works in both dev and prod webviews (prod lacks `clipboard-read` permission
+ * for `navigator.clipboard`, so we bridge through the extension).
+ * @returns Resolves the clipboard text.
+ */
+export async function readClipboard() {
+  postEvent({ type: 'clipboard:read' });
+  return (await waitEvent('clipboard:text')).text;
+}
+
 export function waitEvent<T extends EventMessage['type']>(type: T) {
   return new Promise<EventMessage & { type: T }>((resolve) => {
     const handleMessage = (event: MessageEvent) => {


### PR DESCRIPTION
## Summary

Fixes the production-webview clipboard paste failure reported in #26. In packaged builds, pressing <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>V</kbd> in the Input editor inserts nothing (the built-in Monaco paste silently rejects). This PR bridges clipboard reads through the extension host so paste works in both dev and prod.

Fixes #26.

## Root cause

As analyzed in the [prior comment on #26](https://github.com/typed-sigterm/oi-runner-2/issues/26#issuecomment-4998308907): Monaco ≥ 0.53 appears to use `navigator.clipboard.readText()` for its built-in `editor.action.clipboardPasteAction` (inferred from the version-behavior difference — not yet verified line-by-line against Monaco source). In the **production** VS Code webview this call rejects because the webview lacks the `clipboard-read` permission (no `allow="clipboard-read"` on the host). In **dev** mode `@tomjs/vite-plugin-vscode` wraps the dev server in an iframe that explicitly grants clipboard permissions, which is why dev has always worked.

The v2.1.2 workaround (`584f218`) was a temporary downgrade of `monaco-editor` 0.54 → 0.52 to fall back on `document.execCommand('paste')`. HEAD has since bumped monaco to `^0.55.1`, so the regression is expected to be back (the prior comment flagged that the `@tomjs` major-version bump from `^5.0.0` to `^7.1.1` means the prod-side behavior should be re-confirmed; this PR's fix is version-independent regardless).

## Changes

Bridges clipboard reads through the extension host, mirroring the existing `selectFile()` ↔ `file:select` ↔ `file:selected` round-trip pattern.

| File | Change |
| --- | --- |
| `shared/events.ts` | Add `clipboard:read` (webview → extension) and `clipboard:text` (extension → webview) members to the `EventMessage` union. Placed at the end so the `oj:fetch-samples` / `oj:samples-fetched` request/response pair stays adjacent. |
| `extension/webview.ts` | Handle `clipboard:read` by calling `vscode.env.clipboard.readText()` (which always works in the extension host) and posting the text back as `clipboard:text`. Also adds a `break;` to the previously-terminal `oj:fetch-samples` case — this is **required** to prevent fall-through into the new `clipboard:read` case (and ESLint's `no-fallthrough` enforces it). |
| `src/utils.ts` | Add `readClipboard()`, a thin wrapper around `postEvent({ type: 'clipboard:read' })` + `waitEvent('clipboard:text')`, mirroring `selectFile()`. |
| `src/components/IOPanel.vue` | Register a `oi-runner-2.clipboard.paste` Monaco action with the `CtrlCmd+V` keybinding on editable editors only (skipped when `readonly` or `diff`, so only the Input panel is affected). The action reads the clipboard via `readClipboard()` and inserts at all current selections via `executeEdits` with `forceMoveMarkers: true` (preserves multi-cursor paste parity with the built-in action). |

## Why this approach

- **Version-independent**: does not rely on pinning monaco to a specific version.
- **Symmetric across dev/prod**: both routes read the same system clipboard via `vscode.env.clipboard`, so behavior is identical.
- **Minimal & pattern-faithful**: the new `readClipboard()` is a near 1:1 analogue of `selectFile()`, so a reviewer can pattern-match instead of learning a new convention.

## Out of scope (known limitations)

- **Right-click context-menu "Paste" is not covered.** The context menu still routes to Monaco's built-in `editor.action.clipboardPasteAction`, which is not overridden here and will still fail in prod. Only the keyboard <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>V</kbd> path is bridged. This matches the scope proposed in the prior #26 comment. Happy to follow up with a context-menu override (e.g. via `editor.addAction({ id: 'editor.action.clipboardPasteAction', … })` or a `contextMenuItems` entry) if you'd like — kept it out of this PR to avoid touching built-in command IDs without your sign-off.
- **The second #26 checkbox (body `margin` vs `margin + padding`) is intentionally not addressed.** As noted in the prior comment, prod matches the source (`src/main.css` only declares `margin`); the dev-only padding comes from `@tomjs/vite-plugin-vscode` injecting VS Code's `_defaultStyles` after the app CSS in dev mode. This is a dev-tooling artifact, not a code bug.

## Backward compatibility

- No public API or persisted-state changes (the `EventMessage` union gains two members; existing message flows are untouched).
- In dev mode, <kbd>Ctrl</kbd>+<kbd>V</kbd> now routes through the extension-host bridge instead of Monaco's built-in `navigator.clipboard` path. The clipboard content is identical, so the visible behavior is unchanged. Multi-cursor paste is preserved via `getSelections()`.

## Verification

CI gates all pass locally:

```
pnpm run lint         # clean
pnpm run type-check   # clean
pnpm run build        # succeeds
```

Manual verification (not run here — needs a real VS Code host):

1. `pnpm run build && pnpm run pack` to produce `extension.vsix`.
2. Install the `.vsix` in VS Code.
3. Open a source file, focus the Input editor in the OI Runner panel.
4. Copy some text, press <kbd>Ctrl</kbd>+<kbd>V</kbd> → text should be pasted. (Before this PR: nothing happens.)
5. Optionally verify multi-cursor paste (place two cursors via <kbd>Alt</kbd>+click, paste → both cursors receive the text).

Note: right-click → "Paste" still does nothing in prod — see "Out of scope" above.

## Notes

- No tests added (the repo has no test framework; CI is build + type-check + lint/autofix).
- Commit message follows conventional-commits (`fix(webview): …`) and closes #26 via `Fixes #26`.